### PR TITLE
Fix bug with expected nr of elements on cluster nodes command

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -338,7 +338,7 @@ func (cluster *Cluster) update(node *redisNode) error {
 	}
 
 	t, err := Values(m[2], err)
-	if err != nil || len(t) != 2 {
+	if err != nil || len(t) != 3 {
 	    return errFormat
 	}
 


### PR DESCRIPTION
CLUSTER NODES command returns ip, port AND a hash,
not just ip and port as you expected.
This error leads to clients unable to connect to cluster.
Tested with Redis 3.2.1