### PR TITLE
Add a method that sends a command to each of the cluster nodes

### DIFF
--- a/each.go
+++ b/each.go
@@ -1,0 +1,64 @@
+// Copyright 2015 Joel Wu
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package redis
+
+// DoEach excutes a redis command with random number arguments on each of the nodes in the cluster.
+//
+// The key difference between Do and DoEach is that Do uses the key to calculate the slot and determine
+// which node to call, whereas DoEach will unconditionally execute the command in all nodes of the cluster.
+//
+// Unlike Do, DoEach does not require the first argument to be a key (see example below).
+// The output from this method is the aggregate of the results from each node.
+//
+// See full redis command list: http://www.redis.io/commands
+func (cluster *Cluster) DoEach(cmd string, args ...interface{}) (interface{}, error) {
+	tasks := make([]*multiTask, 0)
+
+	cluster.rwLock.RLock()
+	for _, node := range cluster.nodes {
+
+		task := &multiTask{
+			node: node,
+			cmd:  cmd,
+			args: args,
+			done: make(chan int),
+		}
+		tasks = append(tasks, task)
+	}
+	cluster.rwLock.RUnlock()
+
+	for i := range tasks {
+		go handleEachTask(tasks[i])
+	}
+
+	for i := range tasks {
+		<-tasks[i].done
+	}
+
+	reply := make([]interface{}, 0)
+	for _, task := range tasks {
+		if task.err != nil {
+			return nil, task.err
+		}
+		reply = append(reply, task.replies)
+	}
+
+	return reply, nil
+}
+
+func handleEachTask(task *multiTask) {
+	task.replies, task.err = Values(task.node.do(task.cmd, task.args...))
+	task.done <- 1
+}

--- a/each_test.go
+++ b/each_test.go
@@ -1,0 +1,56 @@
+// Copyright 2015 Joel Wu
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package redis_test
+
+import (
+	"fmt"
+	"github.com/chasex/redis-go-cluster"
+	"time"
+)
+
+// Using SCAN on each node to retrieve a set of keys.
+func ExampleCluster_DoEach_scan() {
+	var err error
+	var cluster *redis.Cluster
+	allKeys := []string{}
+
+	// initialise cluster
+	cluster, err = redis.NewCluster(
+		&redis.Options{
+			StartNodes:   []string{"127.0.0.1:6379", "127.0.0.1:6380", "127.0.0.1:6381"},
+			ConnTimeout:  50 * time.Millisecond,
+			ReadTimeout:  50 * time.Millisecond,
+			WriteTimeout: 50 * time.Millisecond,
+			KeepAlive:    16,
+			AliveTime:    60 * time.Second,
+		},
+	)
+	// add some values for this example
+	_, _ = cluster.Do("MSET", "mykey:1", "a", "mykey:2", "b", "mykey:3", "c")
+
+	// DoEach will execute the SCAN command on each node
+	rawResults, _ := redis.Values(cluster.DoEach("SCAN", 0, "MATCH", "mykey:*"))
+
+	// Loop through the results to retrieve the keys
+	for _, rawResult := range rawResults {
+		nodeValues, _ := redis.Values(rawResult, err)
+		keys, _ := redis.Strings(nodeValues[1], err)
+		for _, key := range keys {
+			allKeys = append(allKeys, key)
+		}
+	}
+	fmt.Println(allKeys)
+	// Output: [mykey:1 mykey:2 mykey:3]
+}


### PR DESCRIPTION
As Redis does not allow cross-slot commands, there are situations when
it becomes necessary to send a single command to all nodes.

This project already supports cross-slot execution of the command
_MGET_ and it would be natural to support other non-cross-slot commands
such as _SCAN_.

The file **each_test.go** contains an example that sends a _SCAN_ command
to all nodes of the cluster. Also note that **each_test.go** is
formatted for `godoc`, so that it becames an example embedded in the
documentation.

Please review and let me know if there are any issues.

Thank you.