### PR TITLE
Grow connection pool up to keepAlive setting

### DIFF
--- a/node.go
+++ b/node.go
@@ -87,7 +87,7 @@ func (node *redisNode) getConn() (*redisConn, error) {
 	}
     }
 
-    if node.conns.Len() <= 0 {
+    if node.conns.Len() < node.keepAlive {
 	node.mutex.Unlock()
 
 	c, err := net.DialTimeout("tcp", node.address, node.connTimeout)


### PR DESCRIPTION
When obtaining a connection, if we are below the keepAlive threshold,
create a new connection instead of reusing existing ones.