### PR TITLE
added support Ping Cmd for the cluster

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -523,6 +523,19 @@ func hash(key string) uint16 {
     return crc16(key[s+1:e]) & (kClusterSlots-1)
 }
 
+func (cluster *Cluster) Ping() (interface{}, error) {
+	responsePing := make(map[string]interface{})
+	for addr, node := range cluster.nodes {
+		reply, err := node.do("ping")
+		if err != nil {
+			return nil, err
+		} else {
+			responsePing[addr] = reply
+		}
+	}
+	return responsePing, nil
+}
+
 func init() {
     log.SetFlags(log.LstdFlags | log.Lshortfile)
 }


### PR DESCRIPTION
_This is my First PR in OS , apologies if done anything wrong._
During integration i didn't find Ping command for health-check for all nodes in the cluster. Tried building it by myself.
 
**Theory:**  it will  run ping command on individual node and accumulate the response, if any node throws error, it will throw the same err.
**example :** 

> reply,err := cluster.Ping()
